### PR TITLE
优化扫码后照片查看器关闭方式

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -16,52 +16,51 @@ func init() {
 var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Open JD’s simulated login",
-	Run: startLogin,
+	Run:   startLogin,
 }
 
-func startLogin(cmd *cobra.Command, args []string)  {
-	session:=jd_seckill.NewSession(common.CookieJar)
+func startLogin(cmd *cobra.Command, args []string) {
+	session := jd_seckill.NewSession(common.CookieJar)
 	//检测是否登录过
 	if common.Exists("./cookie.txt") {
 		//已登录，检测登录状态
-		err:=session.CheckLoginStatus()
-		if err!=nil {
+		err := session.CheckLoginStatus()
+		if err != nil {
 			log.Error("登录失效，请重新登录")
 			return
 		}
-		user:=jd_seckill.NewUser(common.Client,common.Config)
+		user := jd_seckill.NewUser(common.Client, common.Config)
 		log.Println("登录成功")
-		userInfo,_:=user.GetUserInfo()
-		log.Debug("用户:"+userInfo)
-	}else{
+		userInfo, _ := user.GetUserInfo()
+		log.Debug("用户:" + userInfo)
+	} else {
 		//未登录
-		user:=jd_seckill.NewUser(common.Client,common.Config)
-		wlfstkSmdl,err:=user.QrLogin()
-		if err!=nil{
+		user := jd_seckill.NewUser(common.Client, common.Config)
+		wlfstkSmdl, err := user.QrLogin()
+		defer user.DelQrCode()
+		if err != nil {
 			os.Exit(0)
 		}
-		ticket:=""
-		for  {
-			ticket,err=user.QrcodeTicket(wlfstkSmdl)
-			if err==nil && ticket!=""{
+		ticket := ""
+		for {
+			ticket, err = user.QrcodeTicket(wlfstkSmdl)
+			if err == nil && ticket != "" {
 				break
 			}
-			time.Sleep(2*time.Second)
+			time.Sleep(2 * time.Second)
 		}
-		_,err=user.TicketInfo(ticket)
-		//稍微堵塞一秒，防止图像管理器未被关闭，主程序就退出了
-		time.Sleep(1*time.Second)
-		if err==nil {
-			if status:=user.RefreshStatus();status==nil {
+		_, err = user.TicketInfo(ticket)
+		if err == nil {
+			if status := user.RefreshStatus(); status == nil {
 				//保存cookie
-				_=session.SaveCookieToFile("./cookie.txt")
+				_ = session.SaveCookieToFile("./cookie.txt")
 				log.Println("登录成功")
-				userInfo,_:=user.GetUserInfo()
-				log.Debug("用户:"+userInfo)
-			}else{
+				userInfo, _ := user.GetUserInfo()
+				log.Debug("用户:" + userInfo)
+			} else {
 				log.Error("登录失效")
 			}
-		}else{
+		} else {
 			log.Error("登录失败")
 		}
 	}

--- a/common/lib.go
+++ b/common/lib.go
@@ -122,21 +122,18 @@ func OpenImage(qrPath, qrcodeShowType string) {
 		var cmd *exec.Cmd
 		if runtime.GOOS == "windows" {
 			cmd = exec.Command("cmd", "/c", "rundll32.exe", "C:\\Windows\\System32\\shimgvw.dll,ImageView_FullscreenA", qrPath)
-		} else {
-			cmd = exec.Command("open", qrPath)
+		} else if runtime.GOOS == "darwin" {
+			//MacOS下指定使用“预览”打开
+			cmd = exec.Command("open", "-a", "Preview.app", qrPath)
 		}
-		_ = cmd.Start()
 
-		//扫码后二维码自动删除，自动关闭照片查看器
-		go func() {
-			for {
-				time.Sleep(time.Duration(1) * time.Second)
-				if !Exists(qrPath) {
-					_ = exec.Command("taskkill", "/F", "/T", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()
-					break
-				}
+		if cmd != nil {
+			if err := cmd.Start();err == nil{
+				//TODO:照片查看器的进程ID，扫码后自动关闭；MacOS下获取到进程ID不对
+				ViewQrcodePid = cmd.Process.Pid
 			}
-		}()
+		}
+
 		return
 	}
 

--- a/common/var.go
+++ b/common/var.go
@@ -91,4 +91,6 @@ var (
 	Config *goconfig.ConfigFile
 
 	SeckillStatus chan bool
+
+	ViewQrcodePid = 0
 )

--- a/jd_seckill/user.go
+++ b/jd_seckill/user.go
@@ -15,49 +15,51 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"time"
 )
 
 type User struct {
 	client *httpc.HttpClient
-	conf *goconfig.ConfigFile
+	conf   *goconfig.ConfigFile
 }
 
-func NewUser(client *httpc.HttpClient,conf *goconfig.ConfigFile) *User {
-	return &User{client: client,conf:conf }
+func NewUser(client *httpc.HttpClient, conf *goconfig.ConfigFile) *User {
+	return &User{client: client, conf: conf}
 }
 
 func (this *User) getUserAgent() string {
-	return this.conf.MustValue("config","default_user_agent","")
+	return this.conf.MustValue("config", "default_user_agent", "")
 }
 
 func (this *User) loginPage() {
-	req:=httpc.NewRequest(this.client)
-	req.SetHeader("User-Agent",this.getUserAgent())
-	req.SetHeader("Connection","keep-alive")
-	req.SetHeader("Accept","text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3")
-	_,_,_=req.SetUrl("https://passport.jd.com/new/login.aspx").SetMethod("get").Send().End()
+	req := httpc.NewRequest(this.client)
+	req.SetHeader("User-Agent", this.getUserAgent())
+	req.SetHeader("Connection", "keep-alive")
+	req.SetHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3")
+	_, _, _ = req.SetUrl("https://passport.jd.com/new/login.aspx").SetMethod("get").Send().End()
 }
 
-func (this *User) QrLogin() (string,error) {
+func (this *User) QrLogin() (string, error) {
 	//登录页面
 	this.loginPage()
 	//二维码登录
-	req:=httpc.NewRequest(this.client)
-	req.SetHeader("User-Agent",this.getUserAgent())
-	req.SetHeader("Referer","https://passport.jd.com/new/login.aspx")
-	resp,err:=req.SetUrl("https://qr.m.jd.com/show?appid=133&size=300&t="+strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().EndFile(common.SoftDir+"/","qr_code.png")
-	if err!=nil || resp.StatusCode!=http.StatusOK {
+	req := httpc.NewRequest(this.client)
+	req.SetHeader("User-Agent", this.getUserAgent())
+	req.SetHeader("Referer", "https://passport.jd.com/new/login.aspx")
+	resp, err := req.SetUrl("https://qr.m.jd.com/show?appid=133&size=300&t="+strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().EndFile(common.SoftDir+"/", "qr_code.png")
+	if err != nil || resp.StatusCode != http.StatusOK {
 		log.Error("获取二维码失败")
-		return "",errors.New("获取二维码失败")
+		return "", errors.New("获取二维码失败")
 	}
-	cookies:=resp.Cookies()
-	wlfstkSmdl:=""
-	for _,cookie:= range cookies {
-		if cookie.Name=="wlfstk_smdl" {
-			wlfstkSmdl=cookie.Value
+	cookies := resp.Cookies()
+	wlfstkSmdl := ""
+	for _, cookie := range cookies {
+		if cookie.Name == "wlfstk_smdl" {
+			wlfstkSmdl = cookie.Value
 			break
 		}
 	}
@@ -82,17 +84,17 @@ func (this *User) QrLogin() (string,error) {
 		common.OpenImage(qrPath, qrcodeShowType)
 	}
 
-	return wlfstkSmdl,nil
+	return wlfstkSmdl, nil
 }
 
-func (this *User) QrcodeTicket(wlfstkSmdl string) (string,error) {
-	req:=httpc.NewRequest(this.client)
-	req.SetHeader("User-Agent",this.getUserAgent())
-	req.SetHeader("Referer","https://passport.jd.com/new/login.aspx")
-	resp,body,err:=req.SetUrl("https://qr.m.jd.com/check?appid=133&callback=jQuery"+strconv.Itoa(common.Rand(1000000,9999999))+"&token="+wlfstkSmdl+"&_="+strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().End()
-	if err!=nil || resp.StatusCode!=http.StatusOK {
+func (this *User) QrcodeTicket(wlfstkSmdl string) (string, error) {
+	req := httpc.NewRequest(this.client)
+	req.SetHeader("User-Agent", this.getUserAgent())
+	req.SetHeader("Referer", "https://passport.jd.com/new/login.aspx")
+	resp, body, err := req.SetUrl("https://qr.m.jd.com/check?appid=133&callback=jQuery" + strconv.Itoa(common.Rand(1000000, 9999999)) + "&token=" + wlfstkSmdl + "&_=" + strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().End()
+	if err != nil || resp.StatusCode != http.StatusOK {
 		log.Println("获取二维码扫描结果异常")
-		return "",errors.New("获取二维码扫描结果异常")
+		return "", errors.New("获取二维码扫描结果异常")
 	}
 	code := gjson.Get(body, "code").String()
 	msg := gjson.Get(body, "msg").String()
@@ -106,70 +108,84 @@ func (this *User) QrcodeTicket(wlfstkSmdl string) (string,error) {
 		return "", errors.New(fmt.Sprintf("Code: %s, Message: %s", code, msg))
 	}
 	log.Println("已完成手机客户端确认")
-	return gjson.Get(body,"ticket").String(),nil
+	return gjson.Get(body, "ticket").String(), nil
 }
 
-func (this *User) TicketInfo(ticket string) (string,error) {
-	req:=httpc.NewRequest(this.client)
-	req.SetHeader("User-Agent",this.getUserAgent())
-	req.SetHeader("Referer","https://passport.jd.com/uc/login?ltype=logout")
-	resp,body,err:=req.SetUrl("https://passport.jd.com/uc/qrCodeTicketValidation?t="+ticket).SetMethod("get").Send().End()
-	defer this.DelQrCode()
-	if err!=nil || resp.StatusCode!=http.StatusOK {
+func (this *User) TicketInfo(ticket string) (string, error) {
+	req := httpc.NewRequest(this.client)
+	req.SetHeader("User-Agent", this.getUserAgent())
+	req.SetHeader("Referer", "https://passport.jd.com/uc/login?ltype=logout")
+	resp, body, err := req.SetUrl("https://passport.jd.com/uc/qrCodeTicketValidation?t=" + ticket).SetMethod("get").Send().End()
+	if err != nil || resp.StatusCode != http.StatusOK {
 		log.Error("二维码信息校验失败")
-		return "",errors.New("二维码信息校验失败")
+		return "", errors.New("二维码信息校验失败")
 	}
-	if gjson.Get(body,"returnCode").Int()==0 {
+	if gjson.Get(body, "returnCode").Int() == 0 {
 		log.Info("二维码信息校验成功")
-		return "",nil
-	}else{
+		return "", nil
+	} else {
 		log.Error("二维码信息校验失败")
-		return "",errors.New("二维码信息校验失败")
+		return "", errors.New("二维码信息校验失败")
 	}
 }
 
 func (this *User) RefreshStatus() error {
-	client:=httpc.NewHttpClient()
+	client := httpc.NewHttpClient()
 	client.SetCookieJar(common.CookieJar)
 	client.SetRedirect(func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	})
-	req:=httpc.NewRequest(client)
-	req.SetHeader("User-Agent",this.getUserAgent())
-	resp,_,err:=req.SetUrl("https://order.jd.com/center/list.action?rid="+strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().End()
-	if err==nil && resp.StatusCode==http.StatusOK {
+	req := httpc.NewRequest(client)
+	req.SetHeader("User-Agent", this.getUserAgent())
+	resp, _, err := req.SetUrl("https://order.jd.com/center/list.action?rid=" + strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().End()
+	if err == nil && resp.StatusCode == http.StatusOK {
 		return nil
-	}else{
+	} else {
 		return errors.New("登录失效")
 	}
 }
 
-func (this *User) GetUserInfo() (string,error) {
-	req:=httpc.NewRequest(this.client)
-	req.SetHeader("User-Agent",this.getUserAgent())
-	req.SetHeader("Referer","https://order.jd.com/center/list.action")
-	errorCount:=5
-	nickName:=""
-	for  {
-		if errorCount>0 {
-			_,body,_:=req.SetUrl("https://passport.jd.com/user/petName/getUserInfoForMiniJd.action?callback="+strconv.Itoa(common.Rand(1000000,9999999))+"&_="+strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().End()
-			if gjson.Get(body,"nickName").Exists() {
-				nickName=gjson.Get(body,"nickName").String()
+func (this *User) GetUserInfo() (string, error) {
+	req := httpc.NewRequest(this.client)
+	req.SetHeader("User-Agent", this.getUserAgent())
+	req.SetHeader("Referer", "https://order.jd.com/center/list.action")
+	errorCount := 5
+	nickName := ""
+	for {
+		if errorCount > 0 {
+			_, body, _ := req.SetUrl("https://passport.jd.com/user/petName/getUserInfoForMiniJd.action?callback=" + strconv.Itoa(common.Rand(1000000, 9999999)) + "&_=" + strconv.Itoa(int(time.Now().Unix()*1000))).SetMethod("get").Send().End()
+			if gjson.Get(body, "nickName").Exists() {
+				nickName = gjson.Get(body, "nickName").String()
 				break
 			}
-			errorCount=errorCount-1
-			time.Sleep(300*time.Millisecond)
-		}else{
+			errorCount = errorCount - 1
+			time.Sleep(300 * time.Millisecond)
+		} else {
 			break
 		}
 	}
-	b,_:=common.GbkToUtf8([]byte(nickName))
+	b, _ := common.GbkToUtf8([]byte(nickName))
 	return string(b), nil
 }
 
 func (this *User) DelQrCode() {
-	qrPath := filepath.Join(common.SoftDir, `./qr_code.png`)
+	log.Debug("ViewQrcodePid = ", common.ViewQrcodePid)
+	if common.ViewQrcodePid > 0 {
+		var err error
+		if runtime.GOOS == "windows" {
+			err = exec.Command("taskkill", "/F", "/T", "/PID", fmt.Sprint(common.ViewQrcodePid)).Run()
+		} else if runtime.GOOS == "darwin" {
+			//TODO:MacOS下获取到进程ID不对，直接杀所有进程
+			err = exec.Command("pkill", "-f", "Preview").Run()
+		} else {
+			err = exec.Command("kill", "-9", fmt.Sprint(common.ViewQrcodePid)).Run()
+		}
+		if err != nil {
+			log.Warn(err)
+		}
+	}
+	qrPath := filepath.Join(common.SoftDir, "/qr_code.png")
 	if common.Exists(qrPath) {
-		_=os.Remove(qrPath)
+		_ = os.Remove(qrPath)
 	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -62,7 +62,7 @@ func init() {
 
 	// 设置日志级别
 	lvl := "info"
-	if cfg, err := goconfig.LoadConfigFile(softDir+"/conf.ini"); err == nil {
+	if cfg, err := goconfig.LoadConfigFile(softDir + "/conf.ini"); err == nil {
 		lvl, _ = cfg.GetValue("config", "log_level")
 	}
 	atomicLevel := zap.NewAtomicLevel()


### PR DESCRIPTION
1、MacOS下指定使用“预览”打开

2、去掉循环监听文件状态，扫码后二维码自动删除前，先自动关闭照片查看器