### PR TITLE
一些小调整，最后一次PR了

### DIFF
--- a/cmd/jdTdudfp.go
+++ b/cmd/jdTdudfp.go
@@ -37,12 +37,18 @@ func startJdTdudfp(cmd *cobra.Command, args []string) {
 		log.Warn("开始自动获取eid和fp，如遇卡住请结束进程，重新启动")
 		options := []chromedp.ExecAllocatorOption{
 			chromedp.Flag("headless", false),                       //debug使用
+			chromedp.Flag("mute-audio", true),                      //静音
 			chromedp.Flag("blink-settings", "imagesEnabled=false"), //禁用图片加载
 			chromedp.Flag("start-maximized", true),                 //最大化窗口
 			chromedp.Flag("no-sandbox", true),                      //禁用沙盒, 性能优先
-			chromedp.Flag("disable-setuid-sandbox", true),          //禁用setuid沙盒, 性能优先
 			chromedp.Flag("no-default-browser-check", true),        //不检查默认浏览器
-			chromedp.Flag("disable-plugins", true),                 //禁用扩展
+			chromedp.Flag("ignore-certificate-errors", true),       //忽略SSL证书错误
+			chromedp.Flag("disable-gpu", true),                     //禁用GPU加速
+			chromedp.Flag("no-first-run", true),                    //非首次运行
+			chromedp.Flag("disable-plugins", true),                 //禁用插件
+			chromedp.Flag("disable-extensions", false),             //禁用扩展
+			chromedp.Flag("disable-infobars", true),
+			chromedp.Flag("enable-automation", false),
 			chromedp.UserAgent(common.Config.MustValue("config", "default_user_agent", "")),
 		}
 		options = append(chromedp.DefaultExecAllocatorOptions[:], options...)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -30,9 +30,9 @@ func startLogin(cmd *cobra.Command, args []string) {
 			return
 		}
 		user := jd_seckill.NewUser(common.Client, common.Config)
-		log.Println("登录成功")
+		log.Info("登录成功")
 		userInfo, _ := user.GetUserInfo()
-		log.Debug("用户:" + userInfo)
+		log.Info("用户:" + userInfo)
 	} else {
 		//未登录
 		user := jd_seckill.NewUser(common.Client, common.Config)
@@ -54,9 +54,9 @@ func startLogin(cmd *cobra.Command, args []string) {
 			if status := user.RefreshStatus(); status == nil {
 				//保存cookie
 				_ = session.SaveCookieToFile("./cookie.txt")
-				log.Println("登录成功")
+				log.Info("登录成功")
 				userInfo, _ := user.GetUserInfo()
-				log.Debug("用户:" + userInfo)
+				log.Info("用户:" + userInfo)
 			} else {
 				log.Error("登录失效")
 			}

--- a/cmd/seckill.go
+++ b/cmd/seckill.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ztino/jd_seckill/common"
 	"github.com/ztino/jd_seckill/jd_seckill"
 	"github.com/ztino/jd_seckill/log"
+	"math/rand"
 	"os"
 	"regexp"
 	"strconv"
@@ -38,7 +39,10 @@ func startSeckill(cmd *cobra.Command, args []string) {
 		//直接运行抢购跳过等待抢购时间
 		if !isRun {
 			//获取本地时间与京东云端时间差
-			diffTime := seckill.GetDiffTime()
+			diffTime, delayTime := seckill.GetDiffTime()
+			if delayTime > 500 {
+				log.Warn("您的网络请求延时比较严重，请考虑更换网络连接！")
+			}
 
 			//获取抢购时间
 			buyDate := common.Config.MustValue("config", "buy_time", "")
@@ -67,7 +71,7 @@ func startSeckill(cmd *cobra.Command, args []string) {
 				seckillTime = 2
 			}
 
-			timerTime := buyTime - time.Now().UnixNano()/1e6
+			timerTime := buyTime - time.Now().UnixNano()/1e6 - delayTime //减去网络请求延时时间(1次)，用于提前获取秒杀初始化信息
 			if timerTime >= 0 { //等待抢购
 				log.Warn("还没到达抢购时间:", buyDate, "，等待中...")
 				time.Sleep(time.Duration(timerTime) * time.Millisecond)
@@ -79,7 +83,7 @@ func startSeckill(cmd *cobra.Command, args []string) {
 				log.Warn("您已经错过抢购时间，但还在抢购总时间(", seckillTime, "分钟)内，直接执行抢购，祝您好运！")
 			}
 		} else {
-			log.Warn("开始执行……")
+			log.Warn("立即开始抢购……")
 		}
 
 		//提前获取秒杀初始化信息，提高效率，待测试
@@ -108,11 +112,17 @@ func Start(seckill *jd_seckill.Seckill,taskNum int)  {
 	go CheckSeckillStatus()
 	//抢购总时间超时程序自动退出
 	for time.Now().Unix()<seckillTotalTime {
-		for i:=1;i<=taskNum;i++ {
+		rand.Seed(time.Now().Unix())
+		for i := 1; i <= taskNum; i++ {
+			//避免同一时间并发抢购
+			d := rand.Intn(100)
+			time.Sleep(time.Duration(d) * time.Millisecond)
 			go task(seckill)
 		}
 		//怕封号的可以增加间隔时间,相反抢到的成功率也减低了
-		time.Sleep(time.Duration(tickerTime)*time.Millisecond)
+		duration := rand.Intn(tickerTime) + tickerTime
+		log.Warn("休眠", duration, "ms后，发起下一次冲锋")
+		time.Sleep(time.Duration(duration) * time.Millisecond)
 	}
 	log.Warn("抢购结束，具体详情请查看日志")
 }

--- a/common/var.go
+++ b/common/var.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	SoftName          = "jd_seckill"
-	Version           = "0.2.4"
+	Version           = "0.2.6"
 	DateTimeFormatStr = "2006-01-02 15:04:05"
 	DateFormatStr     = "2006-01-02"
 	IniFileContent    = `#默认配置
@@ -30,11 +30,11 @@ seckill_num = 2
 # 抢购开始时间设定 2021-01-01 09:59:59 (PS.预约成功后会自动更新)
 buy_time = 2021-01-01 09:59:59
 # 抢购总时间，单位:分钟，默认两分钟
-seckill_time =
-# 抢购任务数量，默认5个
+seckill_time = 5
+# 抢购任务数量，默认5个（PS.每次发起抢购的线程数量）
 task_num =
-# 每次抢购间隔时间，单位:毫秒，默认1500毫秒，每1000毫秒等于1秒
-ticker_time =
+# 每次抢购最小间隔时间，单位:毫秒，默认1500毫秒，1000毫秒=1秒；最大间隔为2倍，默认3000毫秒（PS.怕封号的可以增加间隔时间,相反抢到的成功率也减低了）
+ticker_time = 500
 # 默认UA
 default_user_agent = Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36
 

--- a/log/log.go
+++ b/log/log.go
@@ -36,7 +36,7 @@ func init() {
 		softDir = dir
 	}
 	fileName := fmt.Sprintf("%s/logs/jd_seckill_%s.log", softDir, time.Now().Format("20060102"))
-	fmt.Println("日志文件：", fileName)
+	fmt.Println("当前日志文件：", fileName)
 	hook := lumberjack.Logger{
 		Filename:   fileName, // 日志文件路径
 		MaxSize:    128,      // 每个日志文件保存的最大尺寸 单位：M
@@ -53,7 +53,7 @@ func init() {
 		MessageKey:     "msg",
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.CapitalColorLevelEncoder,                       //控制台彩色日志输出
+		EncodeLevel:    zapcore.CapitalLevelEncoder,                            //大写DEBUG等标签
 		EncodeTime:     zapcore.TimeEncoderOfLayout("2006-01-02 15:04:05.000"), //时间格式
 		EncodeDuration: zapcore.SecondsDurationEncoder,                         // 时间精度？
 		EncodeCaller:   zapcore.ShortCallerEncoder,                             // 短路径编码器


### PR DESCRIPTION
1、用户信息日志输出调整为info级别

2、每次抢购最小间隔时间增加随机间隔，同一批子进程启动增加随机间隔，避免同一时间并发抢购

3、抢购失败时不要推送消息（仅推送成功信息）

4、日志级别打印去掉颜色（避免cmd/powershell不兼容8bit颜色会乱码）

5、抢购失败返回异常信息时，尝试解析html中的错误信息